### PR TITLE
update audio_capture.py to properly stop audio capture

### DIFF
--- a/custom_components/reflex_audio_capture/audio_capture.py
+++ b/custom_components/reflex_audio_capture/audio_capture.py
@@ -248,7 +248,15 @@ class AudioRecorderPolyfill(rx.Component):
         return rx.call_script(f"refs['mediarecorder_start_{self.get_ref()}']()")
 
     def stop(self):
-        return rx.call_script(f"refs['mediarecorder_{self.get_ref()}']?.stop()")
+        return rx.call_script(
+            f"""
+            const mediaRecorderRef = refs['mediarecorder_{self.get_ref()}'];
+            if (mediaRecorderRef) {{
+                mediaRecorderRef.stop();
+                mediaRecorderRef.stream.getAudioTracks().forEach(track => track.stop());
+            }}
+            """
+        )
 
     @property
     def is_recording(self) -> rx.Var[bool]:


### PR DESCRIPTION
I only have a sample datapoint of one, but on Macs, the microphone remains in use even after the speech capture is turned off. But stopping all tracks takes care of this problem.

P.S: This is a very useful library, thank you for the work 🙌